### PR TITLE
Add padding 00 to fix Hamlib error

### DIFF
--- a/Cat/CatManager.cpp
+++ b/Cat/CatManager.cpp
@@ -438,7 +438,7 @@ void CatManager::PerformCmd(QString str)
 
 		tmpStep = StepToCat[pSdr->MainStep()];
 
-		tmpstr1 = "IF" + tmpFreq + tmpStep + "000000" + "0" + "0" + "0" + "00";
+		tmpstr1 = "IF" + tmpFreq + tmpStep + "000000" + "0" + "0" + "0" + "00" + "00";
 
         tmpstr2.setNum((int)(pSdr->ui->pbMox->isChecked()));
 


### PR DESCRIPTION
Added to fix the following hamlib error seen when running WSJTX with CAT control enabled as Kenwood TS-480:
       Hamlib: kenwood_safe_transaction: wrong answer; len for cmd IF: expected = 37, got 35

Tested this with FLDIGI and FLDIGI was unaffected by this change.
